### PR TITLE
a few bug fixes to get this to run in CUDA 9.2 on TITAN V

### DIFF
--- a/gcorr/src/benchmark_gxkernel.cu
+++ b/gcorr/src/benchmark_gxkernel.cu
@@ -483,7 +483,8 @@ int main(int argc, char *argv[]) {
   dim3 delayPhaseBlocks = dim3(executionsperthread, arguments.nantennas);
   
   // Allocate the memory.
-  int packedBytes = arguments.nsamples * 2 * npolarisations / 8;
+  int max_delay_samples = 32768;
+  int packedBytes = (arguments.nsamples + max_delay_samples) * 2 * npolarisations / 8;
   int packedBytes8 = packedBytes * 4;
   packedData = new int8_t*[arguments.nantennas];
   packedData8 = new int8_t*[arguments.nantennas];

--- a/gcorr/src/gxkernel.cu
+++ b/gcorr/src/gxkernel.cu
@@ -273,9 +273,10 @@ __global__ void unpack2bit_2chan_fast(cuComplex *dest, const int8_t *src, const 
   // const float levels_2bit[4] = {-HiMag, -1.0, 1.0, HiMag};
   const size_t ifft = blockIdx.y;
   const size_t isample = 2*(blockDim.x * blockIdx.x + threadIdx.x) + ifft*fftsamples;
-  int subintsamples = fftsamples * gridDim.y;
-  int8_t src_i = src[(isample - shifts[ifft])/2]; // Here I am just loading src into local memory to 
-                                          // reduce the number of reads from global memory
+  const size_t subintsamples = fftsamples * gridDim.y;
+
+  size_t idx = (isample - shifts[ifft])/2; // FIXME: may lead to memory access outside src[] bounds, see with 'cuda-memcheck ./benchmark_gxkernel'
+  int8_t src_i = src[idx]; // Here I am just loading src into local memory to  reduce the number of reads from global memory
 
   // I have just changed the order of the writes made to dest
   // In theory this should reduce the number of write operations made

--- a/gcorr/src/gxkernel.cu
+++ b/gcorr/src/gxkernel.cu
@@ -204,8 +204,7 @@ __constant__ float kLevels_2bit[4];
 void init_2bitLevels() {
   static const float HiMag = 3.3359;  // Optimal value
   const float lut4level[4] = {-HiMag, -1.0, 1.0, HiMag};
-
-  gpuErrchk(cudaMemcpyToSymbol(kLevels_2bit, lut4level, sizeof(kLevels_2bit)));
+  gpuErrchk(cudaMemcpyToSymbol("kLevels_2bit", lut4level, 0, cudaMemcpyHostToDevice));
 }
 
 


### PR DESCRIPTION
Hi Chris,

I tried to run the benchmark on a 4 x TITAN V system. Didn't succeed at first, but a few bugfixes and additional error checking and packedData[] trailing margin (for delay-shifting unpacker) later it runs and properly reports the execution times.

Btw, on these TITAN V consumer cards there is full support for 16-bit float particularly also in CUFFT. You can check with https://bitbucket.org/jwagner313/gpuspectrometer/raw/master/benchmarking/fp16/ basically 1M-point r2c FFT (and smaller) achieves about twice the throughput with fp16 as compared to fp32. 

Throughput of 1M-point with fp16 is around 33 gigasamples/second on TITAN V.